### PR TITLE
Get paired Id when defineProperty silently fail in IE and Safari

### DIFF
--- a/id.js
+++ b/id.js
@@ -67,22 +67,17 @@ module.exports = function(opts) {
     get: function() {
       if ( ! this.hasOwnProperty(key__) ) {
         try {
+          var existingLocalId = this[key__];
           Object.defineProperty(this, key__, {
             value: nextId(),
             enumerable: false,
           });
+          if (existingLocalId === this[key__]) return getPairedId(this);
         } catch (e) {
           return getPairedId(this);
         }
       }
-
-      // Catch corner case: own property of this[key__] was not actually
-      // created!
-      if ( this.__proto__ && this.__proto__[key] === this[key__] ) {
-        return getPairedId(this);
-      } else {
-        return this[key__];
-      }
+      return this[key__];
     },
     enumerable: false,
   };

--- a/id.js
+++ b/id.js
@@ -72,7 +72,7 @@ module.exports = function(opts) {
             value: nextId(),
             enumerable: false,
           });
-          if (existingLocalId === this[key__]) return getPairedId(this);
+          if ( existingLocalId === this[key__] ) return getPairedId(this);
         } catch (e) {
           return getPairedId(this);
         }


### PR DESCRIPTION
In IE and Safari (version <=9), defineProperty may fail silently. This results to getter function returns a wrong id.